### PR TITLE
feat: add fix command to find fixes for commits on reference branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,6 +136,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "env_logger",
+ "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "4.5.47", features = ["derive"] }
 env_logger = "0.11.8"
+log = "0.4"
 
 [package.metadata.deb]
 maintainer = "Chen Linxuan <me@black-desk.cn>"

--- a/src/commands/fix.rs
+++ b/src/commands/fix.rs
@@ -1,0 +1,317 @@
+/*
+ * SPDX-FileCopyrightText: 2025 2025 Chen Linxuan <me@black-desk.cn>
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+use std::process::Command;
+use log::{debug, warn};
+use crate::utils::commits::CommitInfo;
+
+#[derive(clap::Args)]
+pub struct Args {
+    /// Base commit to start checking from (exclusive)
+    #[arg(long = "base", required = true)]
+    pub base: String,
+
+    /// Reference branch to search for fixes
+    #[arg(long = "ref", required = true)]
+    pub ref_branch: String,
+}
+
+/// Handle the fix command - find fixes for commits on a reference branch
+pub fn command(args: Args) -> Result<(), Box<dyn std::error::Error>> {
+    // Get commits in range base..HEAD
+    let commits_in_range = get_commits_in_range(&args.base, "HEAD")?;
+
+    if commits_in_range.is_empty() {
+        debug!("No commits found in range {}..HEAD", args.base);
+        return Ok(());
+    }
+
+    debug!("Found {} commits in range {}..HEAD", commits_in_range.len(), args.base);
+
+    // Process each commit in the range
+    let mut fix_commits = Vec::new();
+
+    for mut commit in commits_in_range {
+        // Enrich commit info
+        commit.fetch_change_id_if_missing()?;
+        commit.fetch_title_if_missing()?;
+
+        debug!("Processing commit: {} {:?} {:?}",
+               commit.hash, commit.change_id, commit.title);
+
+        // Find original commit on ref branch
+        if let Some(original_commit) = find_original_commit(&commit, &args.ref_branch)? {
+            debug!("Found original commit for {}: {}", commit.hash, original_commit);
+
+            // Search for fixes on ref branch
+            let fixes = find_fixes_for_commit(&original_commit, &args.ref_branch)?;
+
+            if !fixes.is_empty() {
+                debug!("Found {} fix(es) for {}: {:?}", fixes.len(), original_commit, fixes);
+                for fix_commit in fixes {
+                    fix_commits.push(fix_commit);
+                }
+            }
+
+            // Check for references that are not explicit fixes
+            let references = find_references_for_commit(&original_commit, &args.ref_branch)?;
+            debug!("Found {} references for {}: {:?}", references.len(), original_commit, references);
+            for reference in references {
+                debug!("Checking if reference {} is an explicit fix for {}", reference, original_commit);
+                if !is_explicit_fix(&reference, &original_commit)? {
+                    if let Some(ref_title) = get_commit_title(&reference)? {
+                        warn!("Commit {} references {} but is not marked as a fix: {}",
+                              reference, original_commit, ref_title);
+                    } else {
+                        warn!("Commit {} references {} but is not marked as a fix",
+                              reference, original_commit);
+                    }
+                } else {
+                    debug!("Reference {} is an explicit fix, skipping warning", reference);
+                }
+            }
+        } else {
+            debug!("Could not find original commit for {} on {}", commit.hash, args.ref_branch);
+        }
+    }
+
+    // Generate commits file format and output to stdout
+    output_commits_file(&fix_commits)?;
+
+    Ok(())
+}
+
+/// Get commits in the specified range
+fn get_commits_in_range(base: &str, head: &str) -> Result<Vec<CommitInfo>, Box<dyn std::error::Error>> {
+    let range = format!("{}..{}", base, head);
+    let output = Command::new("git")
+        .args(["rev-list", "--reverse", &range])
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("git rev-list failed: {}", stderr).into());
+    }
+
+    let commits_text = String::from_utf8_lossy(&output.stdout);
+    let mut commits = Vec::new();
+
+    for line in commits_text.lines() {
+        let line = line.trim();
+        if !line.is_empty() {
+            commits.push(CommitInfo::from_hash(line.to_string()));
+        }
+    }
+
+    Ok(commits)
+}
+
+/// Find the original commit on ref branch based on change-id or was-change-id
+fn find_original_commit(commit: &CommitInfo, ref_branch: &str) -> Result<Option<String>, Box<dyn std::error::Error>> {
+    if let Some(change_id) = &commit.change_id {
+        // First try to find by change-id
+        if let Some(original) = find_commit_by_change_id(change_id, ref_branch)? {
+            return Ok(Some(original));
+        }
+    }
+
+    // Try to find by was-change-id
+    if let Some(was_change_id) = get_was_change_id(&commit.hash)? {
+        if let Some(original) = find_commit_by_change_id(&was_change_id, ref_branch)? {
+            return Ok(Some(original));
+        }
+    }
+
+    Ok(None)
+}
+
+/// Find commit by change-id on specified branch
+fn find_commit_by_change_id(change_id: &str, ref_branch: &str) -> Result<Option<String>, Box<dyn std::error::Error>> {
+    let output = Command::new("git")
+        .args(["log", "--format=%H", "--grep", &format!("Change-Id: {}", change_id), ref_branch])
+        .output()?;
+
+    if !output.status.success() {
+        return Ok(None);
+    }
+
+    let commits_text = String::from_utf8_lossy(&output.stdout);
+    for line in commits_text.lines() {
+        let line = line.trim();
+        if !line.is_empty() {
+            return Ok(Some(line.to_string()));
+        }
+    }
+
+    Ok(None)
+}
+
+/// Get was-change-id from commit message
+fn get_was_change_id(commit_hash: &str) -> Result<Option<String>, Box<dyn std::error::Error>> {
+    let output = Command::new("git")
+        .args(["log", "--format=%B", "-n", "1", commit_hash])
+        .output()?;
+
+    if !output.status.success() {
+        return Ok(None);
+    }
+
+    let body = String::from_utf8_lossy(&output.stdout);
+    for line in body.lines() {
+        if line.starts_with("Was-Change-Id: I") {
+            if let Some(was_change_id) = line.strip_prefix("Was-Change-Id: ") {
+                return Ok(Some(was_change_id.trim().to_string()));
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+/// Find commits that fix the given commit
+fn find_fixes_for_commit(original_commit: &str, ref_branch: &str) -> Result<Vec<CommitInfo>, Box<dyn std::error::Error>> {
+    debug!("Searching for fixes for commit: {} on branch: {}", original_commit, ref_branch);
+
+    // Get all commits on the ref branch
+    let output = Command::new("git")
+        .args(["log", "--format=%H", ref_branch])
+        .output()?;
+
+    if !output.status.success() {
+        return Ok(Vec::new());
+    }
+
+    let commits_text = String::from_utf8_lossy(&output.stdout);
+    let mut fix_commits = Vec::new();
+
+    for line in commits_text.lines() {
+        let line = line.trim();
+        if !line.is_empty() {
+            debug!("Checking if {} is a fix for {}", line, original_commit);
+            if is_explicit_fix(line, original_commit)? {
+                let mut commit_info = CommitInfo::from_hash(line.to_string());
+                commit_info.fetch_change_id_if_missing()?;
+                commit_info.fetch_title_if_missing()?;
+                fix_commits.push(commit_info);
+                debug!("Found fix commit: {} for {}", line, original_commit);
+            }
+        }
+    }
+
+    debug!("Found {} fix commits for {}", fix_commits.len(), original_commit);
+    Ok(fix_commits)
+}
+
+/// Find commits that reference the given commit (but may not be explicit fixes)
+fn find_references_for_commit(original_commit: &str, ref_branch: &str) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    // Try both full hash and short hash (first 12 chars)
+    let short_hash = &original_commit[..std::cmp::min(12, original_commit.len())];
+
+    debug!("Searching for references using full hash: {} and short hash: {}", original_commit, short_hash);
+
+    let mut all_references = Vec::new();
+
+    // Search with full hash
+    let output = Command::new("git")
+        .args(["log", "--format=%H", "--grep", original_commit, ref_branch])
+        .output()?;
+
+    if output.status.success() {
+        let commits_text = String::from_utf8_lossy(&output.stdout);
+        for line in commits_text.lines() {
+            let line = line.trim();
+            if !line.is_empty() {
+                all_references.push(line.to_string());
+            }
+        }
+    }
+
+    // Search with short hash if different from full hash
+    if short_hash != original_commit {
+        let output = Command::new("git")
+            .args(["log", "--format=%H", "--grep", short_hash, ref_branch])
+            .output()?;
+
+        if output.status.success() {
+            let commits_text = String::from_utf8_lossy(&output.stdout);
+            for line in commits_text.lines() {
+                let line = line.trim();
+                if !line.is_empty() && !all_references.contains(&line.to_string()) {
+                    all_references.push(line.to_string());
+                }
+            }
+        }
+    }
+
+    Ok(all_references)
+}
+
+/// Check if a commit is an explicit fix for the original commit
+fn is_explicit_fix(commit_hash: &str, original_commit: &str) -> Result<bool, Box<dyn std::error::Error>> {
+    let output = Command::new("git")
+        .args(["log", "--format=%B", "-n", "1", commit_hash])
+        .output()?;
+
+    if !output.status.success() {
+        return Ok(false);
+    }
+
+    let body = String::from_utf8_lossy(&output.stdout);
+
+    // Look for various fix patterns
+    for line in body.lines() {
+        let line = line.trim();
+
+        debug!("Checking line: '{}' for fixes of {}", line, original_commit);
+
+        // Pattern: "Fixes: <commit_hash>" (may be short hash)
+        if line.starts_with("Fixes: ") {
+            if let Some(fixes_part) = line.strip_prefix("Fixes: ") {
+                // Extract the commit hash part (before any space or parenthesis)
+                let fixes_hash = fixes_part.split_whitespace().next().unwrap_or("");
+
+                // Check if the fix hash matches the original commit (either full or partial match)
+                if original_commit.starts_with(fixes_hash) || fixes_hash.starts_with(original_commit) {
+                    debug!("Found explicit fix pattern in line: {}", line);
+                    return Ok(true);
+                }
+            }
+        }
+    }
+
+    Ok(false)
+}
+
+/// Get commit title
+fn get_commit_title(commit_hash: &str) -> Result<Option<String>, Box<dyn std::error::Error>> {
+    let output = Command::new("git")
+        .args(["log", "--format=%s", "-n", "1", commit_hash])
+        .output()?;
+
+    if !output.status.success() {
+        return Ok(None);
+    }
+
+    let title = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if title.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(title))
+    }
+}
+
+/// Output commits in file format to stdout
+fn output_commits_file(commits: &[CommitInfo]) -> Result<(), Box<dyn std::error::Error>> {
+    // Add vim modeline
+    println!("# vim: ft=gitbackportcommits");
+
+    // Output each commit
+    for commit in commits {
+        println!("{}", commit.to_line());
+    }
+
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -7,3 +7,4 @@
 pub mod sort;
 pub mod pick;
 pub mod vim;
+pub mod fix;

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,8 @@ enum Commands {
     Pick(commands::pick::Args),
     /// Install vim syntax support files
     Vim(commands::vim::Args),
+    /// Find fixes for commits on a reference branch
+    Fix(commands::fix::Args),
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -42,6 +44,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         Commands::Vim(args) => {
             commands::vim::command(args)?;
+        }
+        Commands::Fix(args) => {
+            commands::fix::command(args)?;
         }
     }
 


### PR DESCRIPTION
- Add new fix.rs module implementing fix command functionality
- Add log dependency to Cargo.toml for debugging output
- Register fix subcommand in main CLI interface
- Find original commits using Change-Id or Was-Change-Id
- Search for explicit fix commits using 'Fixes:' patterns
- Warn about commits that reference but don't explicitly fix
- Output results in gitbackportcommits file format

This commit message is generated by LLM, it might be wrong.
